### PR TITLE
Updated test

### DIFF
--- a/testpack/scripts/ubuntu-16.py
+++ b/testpack/scripts/ubuntu-16.py
@@ -76,13 +76,14 @@ class TestUbuntu16(unittest.TestCase):
         )
 
         sv_log = self.execRun("ls -ld /var/log/supervisor")
+        print("SV_LOG: ", sv_log)
         self.assertFalse(
             sv_log.find("No such file or directory") > -1,
             msg="/var/log/supervisor is missing"
         )
-        self.assertTrue(
-            sv_log.find("rwx ") > -1,
-            msg="/var/log/supervisor permissions don't allow others to write"
+        self.assertEqual(
+            sv_log[8], 'w',
+            msg="/var/log/supervisor is not a writable by others"
         )
 
         self.assertFalse(


### PR DESCRIPTION
For some reason /var/log/supervisor is failing it's test via drone. Hopefully this is an improved test, and extra logging is being provided just in case